### PR TITLE
Use tabular numbers for the timer, stats, and case selection

### DIFF
--- a/style/selection.css
+++ b/style/selection.css
@@ -19,6 +19,7 @@ div.itemUnsel {
 div#cases_selection {
     width: fit-content;
     padding-bottom: 5em;
+    font-variant-numeric: tabular-nums;
 }
 
 img.caseImage {

--- a/style/timer.css
+++ b/style/timer.css
@@ -12,6 +12,7 @@ div#timerDiv {
     justify-content: center;
     align-items: center;
     font-weight: 800;
+    font-variant-numeric: tabular-nums;
 }
 
 div#stats {

--- a/style/timer.css
+++ b/style/timer.css
@@ -17,6 +17,7 @@ div#timerDiv {
 
 div#stats {
     width: 30%;
+    font-variant-numeric: tabular-nums;
 }
 
 div#times {


### PR DESCRIPTION
This change makes the numbers all the same width in these areas to prevent the numbers from jumping around (mainly in the timer). Here is a side-by-side comparison:

![timer](https://github.com/user-attachments/assets/6bc31de9-d9e2-4c32-b687-465b472b0846)
